### PR TITLE
[WIP] Encode length of const expressions

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -787,8 +787,11 @@ and instr_block' s es =
     instr_block' s ((e' @@ region s pos pos) :: es)
 
 let const s =
+  let size = if peek s = Some (0xc5) then (ignore (byte s); len32 s) else 0 in
+  let start = pos s in
   let c = at instr_block s in
   end_ s;
+  if size != 0 then require (pos s = start + size) s start "const expr size mismatch";
   c
 
 

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -728,9 +728,18 @@ struct
     | VecReplace (V128 (F32x4 (V128Op.Replace i))) -> vecop 0x20l; byte i
     | VecReplace (V128 (F64x2 (V128Op.Replace i))) -> vecop 0x22l; byte i
 
-  let const c =
-    list instr c.it; end_ ()
 
+  let const c =
+    if List.length c.it > 1 then begin
+      op 0xc5;
+      let g = gap32 () in
+      let p = pos s in
+      list instr c.it;
+      end_ ();
+      patch_gap32 g (pos s - p)
+    end else begin
+      list instr c.it; end_ ()
+    end
 
   (* Sections *)
 


### PR DESCRIPTION
In order to encode the length of a constant expression we reserve a new point in the opcode space (0xc5). This can only appear as the first byte in a constant expression and is followed by the leb encoding of the length the rest of the expression.

Fixes: #9