### PR TITLE
Remove wabt "Done" link

### DIFF
--- a/proposals/extended-const/Overview.md
+++ b/proposals/extended-const/Overview.md
@@ -51,7 +51,7 @@ instruction:
 - Firefox: [Done](https://github.com/WebAssembly/debugging/issues/17#issuecomment-1041130743)
 - Chrome/v8: [Done](https://chromium.googlesource.com/v8/v8/+/bf1565d7081cabc510e39c42eaea67ea6e79484e)
 - Safari: ?
-- wabt: [Done](https://github.com/WebAssembly/debugging/issues/17#issuecomment-1041130743)
+- wabt: Done
 - llvm: Done
 - binaryen: Done
 - emscripten: Done


### PR DESCRIPTION
It seems like a wrong copy-and-paste from Firefox.